### PR TITLE
Fix jsx syntax errors in design reports

### DIFF
--- a/src/pages/DesignReports.tsx
+++ b/src/pages/DesignReports.tsx
@@ -1430,7 +1430,6 @@ function DesignReports() {
               Share the following order details as an image.
             </DialogDescription>
           </DialogHeader>
-          </DialogHeader>
           <div ref={shareRef} className="invisible" style={{ background: '#fff', padding: 16, borderRadius: 8, marginBottom: 16 }}>
             {shareOrder && (
               <div>


### PR DESCRIPTION
Remove duplicate `</DialogHeader>` tag to fix Netlify build errors.

The Netlify error logs were misleading, indicating a missing dependency. However, the actual issue was a series of TypeScript/JSX syntax errors (e.g., "Expected corresponding JSX closing tag", "JSX expressions must have one parent element") caused by an extra `</DialogHeader>` tag in `DesignReports.tsx`. Removing this duplicate resolves these build failures.

---

[Open in Web](https://www.cursor.com/agents?id=bc-46ae7113-7945-418d-b0fc-c60ad66d0db9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-46ae7113-7945-418d-b0fc-c60ad66d0db9)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)