### PR TITLE
Show full meters and daily totals in Order List

### DIFF
--- a/src/pages/OrderList.tsx
+++ b/src/pages/OrderList.tsx
@@ -177,6 +177,22 @@ export default function OrderList() {
     return matchingOrderIds[currentMatchIdx] === orderId;
   };
 
+  const formatMeters = (meters: number) => `${Math.round(meters)} mtrs`;
+
+  const groupedOrdersByDate = useMemo(() => {
+    return Object.entries(
+      orders.reduce((groups, order) => {
+        const date = format(new Date(order.date), "dd/MM/yyyy");
+        if (!groups[date]) {
+          groups[date] = { orders: [], totalMeters: 0 };
+        }
+        groups[date].orders.push(order);
+        groups[date].totalMeters += order.total_meters || 0;
+        return groups;
+      }, {} as Record<string, { orders: Order[]; totalMeters: number }>)
+    );
+  }, [orders]);
+
 
 
   return (
@@ -208,21 +224,17 @@ export default function OrderList() {
         </span>
       </div>
       <div className="space-y-8">
-        {Object.entries(
-          orders.reduce((groups, order) => {
-            const date = format(new Date(order.date), "dd/MM/yyyy");
-            if (!groups[date]) groups[date] = [];
-            groups[date].push(order);
-            return groups;
-          }, {} as Record<string, Order[]>)
-        ).map(([date, dateOrders]) => (
+        {groupedOrdersByDate.map(([date, dateGroup]) => (
           <div key={date} className="space-y-4">
             <div className="flex items-center gap-4 px-2">
-              <h2 className="text-sm font-bold text-gray-400 uppercase tracking-wider">{date}</h2>
+              <h2 className="text-sm font-bold text-gray-400 uppercase tracking-wider">
+                {date}
+                <span className="ml-2 text-blue-600 normal-case">({formatMeters(dateGroup.totalMeters)})</span>
+              </h2>
               <div className="h-px bg-gray-100 flex-1" />
             </div>
             <div className="space-y-3">
-              {dateOrders.map((order) => (
+              {dateGroup.orders.map((order) => (
                 <div
                   key={order.id}
                   ref={(el) => (itemRefs.current[order.id] = el)}
@@ -237,9 +249,7 @@ export default function OrderList() {
                         {highlightText(`#${String(order.order_no)}`)}
                       </span>
                       <span className="text-sm px-2.5 py-1 bg-blue-50 text-blue-700 rounded-lg font-semibold border border-blue-100">
-                        {order.total_meters >= 1000
-                          ? `${(order.total_meters / 1000).toFixed(1)}k`
-                          : Math.round(order.total_meters)} mtr
+                        {formatMeters(order.total_meters)}
                       </span>
                     </div>
                     <div className="flex gap-2">


### PR DESCRIPTION
### Motivation

- Replace the compact `k` abbreviation for meters with full numeric values and a `mtrs` suffix for clarity (e.g. `9400 mtrs` instead of `9.4k`).
- Surface a per-day total meters summary next to each date heading so users can see daily totals in the same full format.

### Description

- Added a `formatMeters` helper to consistently render meters as ``${Math.round(meters)} mtrs``. 
- Introduced a memoized grouping `groupedOrdersByDate` (via `useMemo`) that aggregates orders per date and computes `totalMeters` for each date. 
- Reworked the render loop to use `groupedOrdersByDate` and display the date-level total using `formatMeters`, and replaced the old `k`-abbreviation logic for individual orders with `formatMeters`.
- Modified file: `src/pages/OrderList.tsx` (grouping, formatting helper, and UI updates).

### Testing

- Ran the production build with `npm run build`, which completed successfully (TypeScript compile + `vite build`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e35f0d6cc8832b91e22cd41c6625ef)