### PR TITLE
Print: make remarks green with black border

### DIFF
--- a/src/pages/BhiwandiListPrint.tsx
+++ b/src/pages/BhiwandiListPrint.tsx
@@ -42,6 +42,9 @@ interface GroupedOrder {
   order_remark: string;
 }
 
+const PRINT_REMARK_STYLE =
+  "color: #008000; border: 1px solid #000; padding: 1px 6px; font-weight: bold; display: inline-block; line-height: 1.2; print-color-adjust: exact; -webkit-print-color-adjust: exact;";
+
 function BhiwandiListPrint() {
   const { date } = useParams<{ date: string }>();
   const [designEntries, setDesignEntries] = useState<GroupedOrder[]>([]);
@@ -111,11 +114,11 @@ function BhiwandiListPrint() {
             <p style="font-size: 18px; line-height: 0.5;">
             <span><strong>Order No.:</strong> ${entry.order_no}
             </span>
-            <span><strong style="color: red; margin:5px; margin-left:40px; line-height:1">${
+            <span style="margin:5px; margin-left:40px;">${
               entry.order_remark && entry.order_remark !== "N/A"
-                ? entry.order_remark
+                ? `<strong style="${PRINT_REMARK_STYLE}">${entry.order_remark}</strong>`
                 : ""
-            }</strong></span>
+            }</span>
             <span></p>
             ${!hideDetails ? `<p style="font-size: 18px; line-height: 0.5"><strong>Transport:</strong> ${entry.transporter_name}</p>` : ''}
           </div>
@@ -142,9 +145,11 @@ function BhiwandiListPrint() {
               <td style="border: 1px solid #ccc; padding-left: 8px; width: ${hideDetails ? '68%' : '55%'}; ">
               <div style="width: 100%; text-align: center; display: flex; flex-direction: row; flex-wrap: wrap;">
               ${formatShades(order.shades)}
-              </div>  <strong style="color: red;">${
-                order.remark && order.remark !== "N/A" ? order.remark : ""
-              }</strong>
+              </div>  ${
+                order.remark && order.remark !== "N/A"
+                  ? `<strong style="${PRINT_REMARK_STYLE}">${order.remark}</strong>`
+                  : ""
+              }
               </td>
             </tr>`;
           });

--- a/src/utils/generateHTML.ts
+++ b/src/utils/generateHTML.ts
@@ -5,6 +5,9 @@ interface Design {
   remark: string;
 }
 
+const PRINT_REMARK_STYLE =
+  "color: #008000; border: 1px solid #000; padding: 1px 6px; font-weight: bold; display: inline-block; line-height: 1.2; print-color-adjust: exact; -webkit-print-color-adjust: exact;";
+
 interface Order {
   designs: Design[];
   orderNo: string;
@@ -415,7 +418,7 @@ function generatePartHTML(
             </div>
             ${
               hasRemark
-                ? `<div style="text-align: center; width: 100%; color: #f00; font-weight: bold; font-size: 14px;">${design.remark}</div>`
+                ? `<div style="text-align: center; width: 100%; font-size: 14px;"><span style="${PRINT_REMARK_STYLE}">${design.remark}</span></div>`
                 : ""
             }
           </div>
@@ -525,8 +528,8 @@ function generatePartHTML(
         </div>
         <div style="border-bottom: 1px solid #000; display: flex; flex-direction: row; min-height: 22px;">
           <div style="width: 10%; text-align: center; align-content: center; display: flex; align-items: center; justify-content: center;">Remark:</div>
-          <div style="width: 90%; word-wrap: break-word; font-weight: bold; color: red; align-content: center; display: flex; align-items: center;">
-            ${part.remark || "N/A"}
+          <div style="width: 90%; word-wrap: break-word; align-content: center; display: flex; align-items: center; padding: 1px;">
+            <span style="${PRINT_REMARK_STYLE}">${part.remark || "N/A"}</span>
           </div>
         </div>
         <div class="designs-container">


### PR DESCRIPTION
### Motivation
- Improve visibility of printed remarks in Order Preview and Bhiwandi List by switching from red text to a green fill with a black border so remarks are clearly legible on printouts.

### Description
- Added a `PRINT_REMARK_STYLE` constant and applied it to remark rendering in `src/utils/generateHTML.ts` so design-entry and order remarks generated for the Order Preview use green text with a black border instead of red. 
- Applied the same `PRINT_REMARK_STYLE` in `src/pages/BhiwandiListPrint.tsx` so both `order_remark` and per-entry `remark` values in the Bhiwandi list print view are rendered with the new green + border styling.

### Testing
- Ran `npm run build`, which completed successfully and produced the production `dist` output. 
- Ran `npm run lint`, which failed due to existing unrelated lint errors elsewhere in the codebase and not related to these style changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ecc74f73c832b8164d8115699656f)