### PR TITLE
Group Bhiwandi entries by calendar date (IST)

### DIFF
--- a/src/pages/DateBhiwandiList.tsx
+++ b/src/pages/DateBhiwandiList.tsx
@@ -45,6 +45,26 @@ const DateBhiwandiList = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
 
+  const getBhiwandiDateKey = (dateString: string): string => {
+    const date = new Date(dateString);
+    const formatter = new Intl.DateTimeFormat("en-CA", {
+      timeZone: "Asia/Kolkata",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+
+    return formatter.format(date);
+  };
+
+  const getNextDateKey = (dateKey: string): string => {
+    const [year, month, day] = dateKey.split("-").map(Number);
+    const date = new Date(Date.UTC(year, month - 1, day));
+    date.setUTCDate(date.getUTCDate() + 1);
+
+    return date.toISOString().split("T")[0];
+  };
+
   const fetchBhiwandiEntries = async () => {
     try {
       const { data, error } = await supabase
@@ -60,7 +80,7 @@ const DateBhiwandiList = () => {
       const groupsMap = new Map<string, DateGroup>();
 
       (data || []).forEach((entry: any) => {
-        const dateStr = entry.bhiwandi_date;
+        const dateStr = getBhiwandiDateKey(entry.bhiwandi_date);
         if (!groupsMap.has(dateStr)) {
           groupsMap.set(dateStr, { bhiwandi_date: dateStr, entries: [], total_entries: 0, total_meters: 0 });
         }
@@ -96,6 +116,7 @@ const DateBhiwandiList = () => {
   const fetchDateEntries = async (dateStr: string) => {
     try {
       setLoadingDates((prev) => ({ ...prev, [dateStr]: true }));
+      const nextDateStr = getNextDateKey(dateStr);
       const { data, error } = await supabase
         .from("design_entries")
         .select(`
@@ -117,7 +138,8 @@ const DateBhiwandiList = () => {
             transport_profiles!orders_transport_id_fkey(name)
           )
         `)
-        .eq("bhiwandi_date", dateStr)
+        .gte("bhiwandi_date", dateStr)
+        .lt("bhiwandi_date", nextDateStr)
         .is("dispatch_date", null)
         .eq("orders.canceled", false);
 


### PR DESCRIPTION
### Motivation
- Visible Bhiwandi lists for the same calendar day were appearing in separate groups because raw timestamps were used as keys, causing items with different timestamp values to render as separate lists. 
- The goal is to normalize dates to an IST calendar-day key and load the full day range so all records that show as the same date are displayed together and printed together.

### Description
- Added `getBhiwandiDateKey` to normalize any `bhiwandi_date` into an IST calendar-day key (`YYYY-MM-DD`).
- Added `getNextDateKey` and changed `fetchDateEntries` to query the day range with `.gte("bhiwandi_date", dateStr)` and `.lt("bhiwandi_date", nextDateStr)` so expanding/printing a date returns all entries for that visible day.
- Updated grouping logic in `fetchBhiwandiEntries` to use the normalized date key when building `groupsMap` so items that display as the same calendar date are clubbed into a single accordion entry.
- Modified file: `src/pages/DateBhiwandiList.tsx`.

### Testing
- Ran `npm run build`, which completed successfully.
- Ran `npm run lint`, which failed but the failures are pre-existing repository lint issues (many `any` usages and empty-interface warnings) not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70966c7848832bbb7d507558396e3e)