### PR TITLE
Add summary duration tabs and trend graph to Dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -30,6 +30,24 @@ interface DesignEntryDetail {
   total_meters: number;
 }
 
+
+type SummaryDuration = "daily" | "weekly" | "15days" | "monthly";
+
+const SUMMARY_TABS: { value: SummaryDuration; label: string; days: number }[] = [
+  { value: "daily", label: "Daily", days: 1 },
+  { value: "weekly", label: "Weekly", days: 7 },
+  { value: "15days", label: "15 Day", days: 15 },
+  { value: "monthly", label: "Monthly", days: 30 },
+];
+
+interface SummaryGraphPoint {
+  date: string;
+  orders: number;
+  bhiwandi: number;
+  dispatched: number;
+  cancelled: number;
+}
+
 export default function Dashboard() {
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -42,6 +60,8 @@ export default function Dashboard() {
   };
 
   const [selectedDateStr, setSelectedDateStr] = useState(getTodayISTString());
+  const [summaryDuration, setSummaryDuration] = useState<SummaryDuration>("daily");
+  const selectedSummaryTab = SUMMARY_TABS.find((tab) => tab.value === summaryDuration) || SUMMARY_TABS[0];
 
   // Global States
   const [loadingGlobal, setLoadingGlobal] = useState(true);
@@ -75,6 +95,7 @@ export default function Dashboard() {
   const [todaysCancelledEntries, setTodaysCancelledEntries] = useState<DesignEntryDetail[]>([]);
   const [todaysCancelledMeters, setTodaysCancelledMeters] = useState(0);
   const [isCancelledCollapsed, setIsCancelledCollapsed] = useState(true);
+  const [summaryGraphData, setSummaryGraphData] = useState<SummaryGraphPoint[]>([]);
 
   // Order preview state
   const [previewOrder, setPreviewOrder] = useState<OrderDetail | null>(null);
@@ -97,13 +118,35 @@ export default function Dashboard() {
     setSelectedDateStr(d.toISOString().split("T")[0]);
   };
 
+  const getSummaryDateRange = () => {
+    const endDate = new Date(`${selectedDateStr}T00:00:00Z`);
+    const startDate = new Date(endDate);
+    startDate.setUTCDate(endDate.getUTCDate() - selectedSummaryTab.days + 1);
+
+    return {
+      startDateStr: startDate.toISOString().split("T")[0],
+      endDateStr: selectedDateStr,
+      startDateTime: `${startDate.toISOString().split("T")[0]}T00:00:00`,
+      endDateTime: `${selectedDateStr}T23:59:59.999`,
+    };
+  };
+
+  const getSummaryDateKeys = () => {
+    const { startDateStr } = getSummaryDateRange();
+    return Array.from({ length: selectedSummaryTab.days }, (_, index) => {
+      const d = new Date(`${startDateStr}T00:00:00Z`);
+      d.setUTCDate(d.getUTCDate() + index);
+      return d.toISOString().split("T")[0];
+    });
+  };
+
   const fetchGlobalAggregates = async () => {
     setLoadingGlobal(true);
     try {
       // 1. Pending Production (No Bhiwandi AND No Dispatch)
       const { data: pendingData, error: pendingError } = await supabase
         .from("design_entries")
-        .select(`shades, orders!inner(canceled)`)
+        .select(`shades, bhiwandi_date, orders!inner(canceled)`)
         .is("bhiwandi_date", null)
         .is("dispatch_date", null)
         .eq("orders.canceled", false);
@@ -115,7 +158,7 @@ export default function Dashboard() {
       // 2. Pending Dispatch (Has Bhiwandi AND No Dispatch)
       const { data: dispatchData, error: dispatchError } = await supabase
         .from("design_entries")
-        .select(`shades, orders!inner(canceled)`)
+        .select(`shades, bhiwandi_date, orders!inner(canceled)`)
         .not("bhiwandi_date", "is", null)
         .is("dispatch_date", null)
         .eq("orders.canceled", false);
@@ -139,38 +182,51 @@ export default function Dashboard() {
   const fetchDateAggregates = async () => {
     setLoadingDate(true);
     try {
-      const startOfDay = `${selectedDateStr}T00:00:00`;
-      const endOfDay = `${selectedDateStr}T23:59:59.999`;
+      const { startDateStr, endDateStr, startDateTime, endDateTime } = getSummaryDateRange();
+      const graphMap = getSummaryDateKeys().reduce<Record<string, SummaryGraphPoint>>((acc, date) => {
+        acc[date] = { date, orders: 0, bhiwandi: 0, dispatched: 0, cancelled: 0 };
+        return acc;
+      }, {});
 
-      // 1. New orders on selected date
+      // 1. New orders in selected summary range
       const { data: ordersData, error: ordersError } = await supabase
         .from("orders")
-        .select(`total_meters, canceled`)
-        .eq("date", selectedDateStr)
+        .select(`date, total_meters, canceled`)
+        .gte("date", startDateStr)
+        .lte("date", endDateStr)
         .eq("canceled", false);
 
       if (ordersError) throw ordersError;
-      const ordersSum = (ordersData || []).reduce((sum, row: any) => sum + (Number(row.total_meters) || 0), 0);
+      const ordersSum = (ordersData || []).reduce((sum, row: any) => {
+        const meters = Number(row.total_meters) || 0;
+        if (graphMap[row.date]) graphMap[row.date].orders += meters;
+        return sum + meters;
+      }, 0);
       setTodaysOrdersMeters(ordersSum);
 
       // 2. Bhiwandi entries on selected date
       const { data: bhiwandiData, error: bhiwandiError } = await supabase
         .from("design_entries")
-        .select(`shades, orders!inner(canceled)`)
-        .gte("bhiwandi_date", startOfDay)
-        .lte("bhiwandi_date", endOfDay)
+        .select(`shades, bhiwandi_date, orders!inner(canceled)`)
+        .gte("bhiwandi_date", startDateTime)
+        .lte("bhiwandi_date", endDateTime)
         .eq("orders.canceled", false);
 
       if (bhiwandiError) throw bhiwandiError;
-      const bhiwandiSum = (bhiwandiData || []).reduce((sum, row: any) => sum + sumShadesMeters(row.shades), 0);
+      const bhiwandiSum = (bhiwandiData || []).reduce((sum, row: any) => {
+        const meters = sumShadesMeters(row.shades);
+        const dateKey = row.bhiwandi_date?.split("T")[0];
+        if (dateKey && graphMap[dateKey]) graphMap[dateKey].bhiwandi += meters;
+        return sum + meters;
+      }, 0);
       setTodaysBhiwandiMeters(bhiwandiSum);
 
       // 3. Dispatched & Cancelled entries on selected date
       const { data: dispatchData, error: dispatchError } = await supabase
         .from("design_entries")
-        .select(`shades, remark, orders!inner(canceled)`)
-        .gte("dispatch_date", startOfDay)
-        .lte("dispatch_date", endOfDay)
+        .select(`shades, remark, dispatch_date, orders!inner(canceled)`)
+        .gte("dispatch_date", startDateTime)
+        .lte("dispatch_date", endDateTime)
         .eq("orders.canceled", false);
 
       if (dispatchError) throw dispatchError;
@@ -178,8 +234,19 @@ export default function Dashboard() {
       const actualDispatched = (dispatchData || []).filter((r: any) => r.remark !== "Entry Cancelled");
       const actualCancelled = (dispatchData || []).filter((r: any) => r.remark === "Entry Cancelled");
 
-      setTodaysDispatchMeters(actualDispatched.reduce((sum, row: any) => sum + sumShadesMeters(row.shades), 0));
-      setTodaysCancelledMeters(actualCancelled.reduce((sum, row: any) => sum + sumShadesMeters(row.shades), 0));
+      setTodaysDispatchMeters(actualDispatched.reduce((sum, row: any) => {
+        const meters = sumShadesMeters(row.shades);
+        const dateKey = row.dispatch_date?.split("T")[0];
+        if (dateKey && graphMap[dateKey]) graphMap[dateKey].dispatched += meters;
+        return sum + meters;
+      }, 0));
+      setTodaysCancelledMeters(actualCancelled.reduce((sum, row: any) => {
+        const meters = sumShadesMeters(row.shades);
+        const dateKey = row.dispatch_date?.split("T")[0];
+        if (dateKey && graphMap[dateKey]) graphMap[dateKey].cancelled += meters;
+        return sum + meters;
+      }, 0));
+      setSummaryGraphData(Object.values(graphMap));
 
     } catch (err: any) {
       console.error("Error fetching date aggregates:", err);
@@ -248,7 +315,8 @@ export default function Dashboard() {
           id, order_no, date, remark, total_meters, canceled,
           party_profiles!orders_bill_to_id_fkey(name)
         `)
-        .eq("date", selectedDateStr)
+        .gte("date", getSummaryDateRange().startDateStr)
+        .lte("date", getSummaryDateRange().endDateStr)
         .eq("canceled", false);
       if (error) throw error;
       const formatted = (data || []).map((row: any) => ({
@@ -263,16 +331,15 @@ export default function Dashboard() {
     if (todaysBhiwandiEntries.length > 0) return;
     setLoadingBhiwandi(true);
     try {
-      const startOfDay = `${selectedDateStr}T00:00:00`;
-      const endOfDay = `${selectedDateStr}T23:59:59.999`;
+      const { startDateTime, endDateTime } = getSummaryDateRange();
       const { data, error } = await supabase
         .from("design_entries")
         .select(`
           id, design, price, remark, shades, bhiwandi_date,
           orders!inner(order_no, date, remark, canceled, party_profiles!orders_bill_to_id_fkey(name))
         `)
-        .gte("bhiwandi_date", startOfDay)
-        .lte("bhiwandi_date", endOfDay)
+        .gte("bhiwandi_date", startDateTime)
+        .lte("bhiwandi_date", endDateTime)
         .eq("orders.canceled", false);
       if (error) throw error;
       const formatted = (data || []).map((row: any) => ({
@@ -287,16 +354,15 @@ export default function Dashboard() {
     if (todaysDispatchEntries.length > 0 || todaysCancelledEntries.length > 0) return;
     setLoadingDispatch(true);
     try {
-      const startOfDay = `${selectedDateStr}T00:00:00`;
-      const endOfDay = `${selectedDateStr}T23:59:59.999`;
+      const { startDateTime, endDateTime } = getSummaryDateRange();
       const { data, error } = await supabase
         .from("design_entries")
         .select(`
           id, design, price, remark, shades, dispatch_date,
           orders!inner(order_no, date, remark, canceled, party_profiles!orders_bill_to_id_fkey(name))
         `)
-        .gte("dispatch_date", startOfDay)
-        .lte("dispatch_date", endOfDay)
+        .gte("dispatch_date", startDateTime)
+        .lte("dispatch_date", endDateTime)
         .eq("orders.canceled", false);
       if (error) throw error;
       const formatted = (data || []).map((row: any) => ({
@@ -340,10 +406,39 @@ export default function Dashboard() {
     setTodaysDispatchEntries([]);
     setTodaysCancelledEntries([]);
     fetchDateAggregates();
-  }, [selectedDateStr]);
+  }, [selectedDateStr, summaryDuration]);
 
   const formatMeters = (m: number) => `${Math.round(m)} mtr`;
   const isToday = selectedDateStr === getTodayISTString();
+
+  const summaryRangeLabel = (() => {
+    const { startDateStr, endDateStr } = getSummaryDateRange();
+    if (startDateStr === endDateStr) return format(parseISO(endDateStr), "dd MMM yyyy");
+    return `${format(parseISO(startDateStr), "dd MMM")} - ${format(parseISO(endDateStr), "dd MMM yyyy")}`;
+  })();
+
+  const graphMetrics = [
+    { key: "orders", label: "New Orders", color: "#2563eb" },
+    { key: "bhiwandi", label: "Sent to Bhiwandi", color: "#6366f1" },
+    { key: "dispatched", label: "Dispatched", color: "#10b981" },
+    { key: "cancelled", label: "Cancelled", color: "#ef4444" },
+  ] as const;
+
+  const maxGraphValue = Math.max(
+    1,
+    ...summaryGraphData.flatMap((point) => graphMetrics.map((metric) => point[metric.key]))
+  );
+
+  const getGraphPolyline = (key: (typeof graphMetrics)[number]["key"]) => {
+    if (summaryGraphData.length === 0) return "";
+    return summaryGraphData
+      .map((point, index) => {
+        const x = summaryGraphData.length === 1 ? 50 : (index / (summaryGraphData.length - 1)) * 100;
+        const y = 100 - (point[key] / maxGraphValue) * 85;
+        return `${x},${y}`;
+      })
+      .join(" ");
+  };
 
   return (
     <div className="min-h-screen bg-slate-50/50 pb-12">
@@ -502,12 +597,28 @@ export default function Dashboard() {
 
         {/* AREA B: Date Dashboard */}
         <section className="bg-white rounded-xl border border-slate-200 shadow-sm p-4 md:p-6">
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6 pb-6 border-b border-slate-100">
-            <h2 className="text-base font-bold text-slate-800 flex items-center gap-2">
-              <Calendar className="h-5 w-5 text-blue-600" />
-              Daily Summary
-              {loadingDate && <span className="w-4 h-4 border-2 border-slate-300 border-t-slate-600 rounded-full animate-spin ml-2" />}
-            </h2>
+          <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4 mb-6 pb-6 border-b border-slate-100">
+            <div className="space-y-3">
+              <h2 className="text-base font-bold text-slate-800 flex items-center gap-2">
+                <Calendar className="h-5 w-5 text-blue-600" />
+                {selectedSummaryTab.label} Summary
+                {loadingDate && <span className="w-4 h-4 border-2 border-slate-300 border-t-slate-600 rounded-full animate-spin ml-2" />}
+              </h2>
+              <div className="flex flex-wrap gap-2">
+                {SUMMARY_TABS.map((tab) => (
+                  <Button
+                    key={tab.value}
+                    variant={summaryDuration === tab.value ? "default" : "outline"}
+                    size="sm"
+                    className={summaryDuration === tab.value ? "bg-blue-600 hover:bg-blue-700" : "bg-white"}
+                    onClick={() => setSummaryDuration(tab.value)}
+                  >
+                    {tab.label}
+                  </Button>
+                ))}
+              </div>
+              <p className="text-xs font-medium text-slate-500">Showing {summaryRangeLabel}</p>
+            </div>
             
             {/* Simple Date Picker */}
             <div className="flex items-center bg-slate-50 border border-slate-200 rounded-lg p-1 w-full sm:w-auto justify-between sm:justify-start shadow-sm">
@@ -522,6 +633,55 @@ export default function Dashboard() {
               </Button>
             </div>
           </div>
+
+          <Card className="mb-6 border border-slate-100 bg-gradient-to-br from-white to-slate-50 shadow-sm">
+            <CardContent className="p-4 md:p-5">
+              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4">
+                <div>
+                  <h3 className="text-sm font-bold text-slate-800">Metric trend</h3>
+                  <p className="text-xs text-slate-500">Daily movement changes with the selected summary duration.</p>
+                </div>
+                <div className="flex flex-wrap gap-3">
+                  {graphMetrics.map((metric) => (
+                    <span key={metric.key} className="flex items-center gap-1.5 text-xs font-semibold text-slate-600">
+                      <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: metric.color }} />
+                      {metric.label}
+                    </span>
+                  ))}
+                </div>
+              </div>
+              <div className="h-64 w-full rounded-lg border border-slate-100 bg-white p-3">
+                <svg viewBox="0 0 100 100" preserveAspectRatio="none" className="h-full w-full overflow-visible">
+                  {[15, 36.25, 57.5, 78.75, 100].map((y) => (
+                    <line key={y} x1="0" x2="100" y1={y} y2={y} stroke="#e2e8f0" strokeWidth="0.35" />
+                  ))}
+                  {graphMetrics.map((metric) => (
+                    <polyline
+                      key={metric.key}
+                      points={getGraphPolyline(metric.key)}
+                      fill="none"
+                      stroke={metric.color}
+                      strokeWidth="1.8"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      vectorEffect="non-scaling-stroke"
+                    />
+                  ))}
+                  {summaryGraphData.map((point, index) => {
+                    const x = summaryGraphData.length === 1 ? 50 : (index / (summaryGraphData.length - 1)) * 100;
+                    return graphMetrics.map((metric) => {
+                      const y = 100 - (point[metric.key] / maxGraphValue) * 85;
+                      return <circle key={`${point.date}-${metric.key}`} cx={x} cy={y} r="1.2" fill={metric.color} vectorEffect="non-scaling-stroke" />;
+                    });
+                  })}
+                </svg>
+              </div>
+              <div className="mt-3 flex justify-between text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+                <span>{summaryGraphData[0] ? format(parseISO(summaryGraphData[0].date), "dd MMM") : "Start"}</span>
+                <span>{summaryGraphData[summaryGraphData.length - 1] ? format(parseISO(summaryGraphData[summaryGraphData.length - 1].date), "dd MMM") : "End"}</span>
+              </div>
+            </CardContent>
+          </Card>
 
           <div className="space-y-4">
             {/* Section 1: Date Orders */}
@@ -550,7 +710,7 @@ export default function Dashboard() {
                   {loadingTodaysOrders ? (
                     <div className="p-8 text-center text-sm text-slate-400">Loading details...</div>
                   ) : todaysOrders.length === 0 ? (
-                    <div className="p-8 text-center text-sm text-slate-400">No orders created on this date.</div>
+                    <div className="p-8 text-center text-sm text-slate-400">No orders created in this period.</div>
                   ) : (
                     <div className="divide-y divide-slate-100 max-h-80 overflow-y-auto">
                       {todaysOrders.map((order) => (
@@ -597,7 +757,7 @@ export default function Dashboard() {
                     {loadingBhiwandi ? (
                       <div className="p-8 text-center text-sm text-slate-400">Loading...</div>
                     ) : todaysBhiwandiEntries.length === 0 ? (
-                      <div className="p-8 text-center text-sm text-slate-400">Nothing sent to Bhiwandi.</div>
+                      <div className="p-8 text-center text-sm text-slate-400">Nothing sent to Bhiwandi in this period.</div>
                     ) : (
                       <div className="divide-y divide-slate-100 max-h-80 overflow-y-auto">
                         {todaysBhiwandiEntries.map((item) => (


### PR DESCRIPTION
### Motivation
- Provide flexible summaries (Daily, Weekly, 15 Day, Monthly) in the dashboard summary area so users can change the reporting window. 
- Show a multi-metric trend graph that updates when the selected summary duration changes. 
- Reuse the same date range for summary aggregates and detail lists so totals and lists reflect the selected period.

### Description
- Added summary duration types, `SUMMARY_TABS`, and state `summaryDuration`/`selectedSummaryTab` and UI buttons for tab selection in the dashboard header. (primary change: `src/pages/Dashboard.tsx`).
- Implemented `getSummaryDateRange` and `getSummaryDateKeys` helpers and updated `fetchDateAggregates` to query orders, bhiwandi, dispatch and cancellations across the selected range and build `summaryGraphData` for the chart. (modified query ranges and mapping logic).
- Updated detail fetchers (`fetchTodaysOrdersDetails`, `fetchBhiwandiDetails`, `fetchDispatchDetails`) to use the selected summary date range instead of a single day so the expandable lists reflect the chosen window.
- Added an inline, color-coded SVG trend chart and helper functions (`graphMetrics`, `getGraphPolyline`, `maxGraphValue`) that render metrics (`New Orders`, `Sent to Bhiwandi`, `Dispatched`, `Cancelled`) and update when the tab is changed; also updated effect dependencies to refresh when `summaryDuration` changes.

### Testing
- `npm run build` was executed and completed successfully (production build created). 
- `npm run lint` was executed and failed due to existing repo-wide ESLint/TypeScript issues (many pre-existing `any` usages and other lint errors), so lint did not pass for the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a773e589e10832b94793057273ba60f)