### PR TITLE
Show program on Party Wise Order table

### DIFF
--- a/src/components/custom/PartyOrderTable.tsx
+++ b/src/components/custom/PartyOrderTable.tsx
@@ -75,6 +75,12 @@ export function PartyOrderTable({
                         Price: {order.price}
                       </>
                     )}
+                    {order.program && (
+                      <>
+                        <br />
+                        Program: {order.program}
+                      </>
+                    )}
                     {order.order_date && (
                       <>
                         <br />


### PR DESCRIPTION
### Motivation
- Display the program text for each design entry in the Party Wise order view when a `program` value exists.

### Description
- Add conditional rendering of `Program: {order.program}` in `src/components/custom/PartyOrderTable.tsx` so the program is shown beneath the design entry details when present.

### Testing
- Ran `npm run build` which completed successfully, and ran `npm run lint` which failed due to pre-existing lint errors unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f02420c38832baac12048fab7cae3)